### PR TITLE
Now has an optional filter which allows for the passing of variable p…

### DIFF
--- a/src/Meta_Box.php
+++ b/src/Meta_Box.php
@@ -98,7 +98,7 @@ class Meta_Box {
 	 * Filter for pushing post specific data into the views
 	 * global variable scope
 	 *
-	 * @var null|callable(array<string, mixed> $args):array<string, mixed>
+	 * @var null|callable(\WP_Post $post,array<string, mixed> $args):array<string, mixed>
 	 */
 	public $view_data_filter;
 
@@ -215,7 +215,7 @@ class Meta_Box {
 	/**
 	 * Set $args):args
 	 *
-	 * @param callable(array<string, mixed> $args):array<string, mixed> $view_data_filter
+	 * @param callable(\WP_Post $post,array<string, mixed> $args):array<string, mixed> $view_data_filter
 	 * @return self
 	 */
 	public function view_data_filter( callable $view_data_filter ): self {

--- a/src/Meta_Box.php
+++ b/src/Meta_Box.php
@@ -95,6 +95,14 @@ class Meta_Box {
 	public $actions = array();
 
 	/**
+	 * Filter for pushing post specific data into the views
+	 * global variable scope
+	 *
+	 * @var null|callable(array<string, mixed> $args):array<string, mixed>
+	 */
+	public $view_data_filter;
+
+	/**
 	 * Creates a MetaBox with a defined key.
 	 *
 	 * @param string $key
@@ -203,4 +211,15 @@ class Meta_Box {
 		return $this;
 	}
 
+
+	/**
+	 * Set $args):args
+	 *
+	 * @param callable(array<string, mixed> $args):array<string, mixed> $view_data_filter
+	 * @return self
+	 */
+	public function view_data_filter( callable $view_data_filter ): self {
+		$this->view_data_filter = $view_data_filter;
+		return $this;
+	}
 }

--- a/src/Registrar/Meta_Box_Registrar.php
+++ b/src/Registrar/Meta_Box_Registrar.php
@@ -124,7 +124,7 @@ class Meta_Box_Registrar {
 
 				// Set the view args
 				$args['args']['post'] = $post;
-				$args['args']         = $this->filter_view_args( $meta_box, $args['args'] );
+				$args['args']         = $this->filter_view_args( $meta_box, $post, $args['args'] );
 
 				// Render the callback.
 				if ( \is_callable( $current_callback ) ) {
@@ -154,7 +154,7 @@ class Meta_Box_Registrar {
 			function ( \WP_Post $post, array $args ) use ( $meta_box, $view ) {
 
 				$args['args']['post'] = $post;
-				$args['args']         = $this->filter_view_args( $meta_box, $args['args'] );
+				$args['args']         = $this->filter_view_args( $meta_box, $post, $args['args'] );
 
 				// @phpstan-ignore-next-line, template should already be checked for valid template path in register() method (which calls this)
 				$view->render( $meta_box->view_template, $args['args'] );
@@ -185,9 +185,9 @@ class Meta_Box_Registrar {
 	 * @param array<string, mixed> $view_args
 	 * @return array<string, mixed>
 	 */
-	public function filter_view_args( Meta_Box $meta_box, array $view_args ): array {
+	public function filter_view_args( Meta_Box $meta_box, \WP_Post $post, array $view_args ): array {
 		if ( is_callable( $meta_box->view_data_filter ) ) {
-			$view_args = ( $meta_box->view_data_filter )( $view_args );
+			$view_args = ( $meta_box->view_data_filter )( $post, $view_args );
 		}
 		return $view_args;
 	}

--- a/src/Registrar/Meta_Box_Registrar.php
+++ b/src/Registrar/Meta_Box_Registrar.php
@@ -78,7 +78,10 @@ class Meta_Box_Registrar {
 
 		// Set the view using View, if not traditional callback supplied and a defined template.
 		if ( ! \is_callable( $meta_box->view ) && is_string( $meta_box->view_template ) ) {
-			$meta_box = $this->set_view_callback_from_view( $meta_box );
+			$meta_box = $this->set_view_callback_from_renderable( $meta_box );
+		}
+		if ( \is_callable( $meta_box->view ) ) {
+			$meta_box = $this->set_view_callback_from_callable( $meta_box );
 		}
 
 		// Add meta_box to loader.
@@ -106,12 +109,40 @@ class Meta_Box_Registrar {
 	}
 
 	/**
+	 * Sets the view callback for a view which is defined as a callback.
+	 *
+	 * @param \PinkCrab\Registerables\Meta_Box $meta_box
+	 * @return \PinkCrab\Registerables\Meta_Box
+	 */
+	protected function set_view_callback_from_callable( Meta_Box $meta_box ): Meta_Box {
+
+		// Get the current view callback.
+		$current_callback = $meta_box->view;
+
+		$meta_box->view(
+			function ( \WP_Post $post, array $args ) use ( $meta_box, $current_callback ) {
+
+				// Set the view args
+				$args['args']['post'] = $post;
+				$args['args']         = $this->filter_view_args( $meta_box, $args['args'] );
+
+				// Render the callback.
+				if ( \is_callable( $current_callback ) ) {
+					call_user_func( $current_callback, $post, $args );
+				}
+			}
+		);
+
+		return $meta_box;
+	}
+
+	/**
 	 * Apply rendering the view using View to a meta_box
 	 *
 	 * @param \PinkCrab\Registerables\Meta_Box $meta_box
 	 * @return \PinkCrab\Registerables\Meta_Box
 	 */
-	protected function set_view_callback_from_view( Meta_Box $meta_box ): Meta_Box {
+	protected function set_view_callback_from_renderable( Meta_Box $meta_box ): Meta_Box {
 
 		// Create View(View)
 		$view = $this->container->create( View::class );
@@ -121,7 +152,9 @@ class Meta_Box_Registrar {
 
 		$meta_box->view(
 			function ( \WP_Post $post, array $args ) use ( $meta_box, $view ) {
+
 				$args['args']['post'] = $post;
+				$args['args']         = $this->filter_view_args( $meta_box, $args['args'] );
 
 				// @phpstan-ignore-next-line, template should already be checked for valid template path in register() method (which calls this)
 				$view->render( $meta_box->view_template, $args['args'] );
@@ -142,5 +175,20 @@ class Meta_Box_Registrar {
 		return ! is_null( $current_screen )
 		&& ! empty( $current_screen->post_type )
 		&& in_array( $current_screen->post_type, $meta_box->screen, true );
+	}
+
+	/**
+	 * Filters the render time args through the optional
+	 * callback definition in model class.
+	 *
+	 * @param \PinkCrab\Registerables\Meta_Box $meta_box
+	 * @param array<string, mixed> $view_args
+	 * @return array<string, mixed>
+	 */
+	public function filter_view_args( Meta_Box $meta_box, array $view_args ): array {
+		if ( is_callable( $meta_box->view_data_filter ) ) {
+			$view_args = ( $meta_box->view_data_filter )( $view_args );
+		}
+		return $view_args;
 	}
 }

--- a/tests/App_Helper_Trait.php
+++ b/tests/App_Helper_Trait.php
@@ -15,12 +15,15 @@ declare(strict_types=1);
 namespace PinkCrab\Registerables\Tests;
 
 use PinkCrab\Perique\Application\App;
+use PinkCrab\Perique\Services\View\View;
 use PinkCrab\Registerables\Registration_Middleware\Registerable_Middleware;
 use PinkCrab\Loader\Hook_Loader;
 use Dice\Dice;
 use PinkCrab\Perique\Services\Dice\PinkCrab_Dice;
 use PinkCrab\Perique\Services\Registration\Registration_Service;
 use Gin0115\WPUnit_Helpers\Objects;
+use PinkCrab\Perique\Interfaces\Renderable;
+use PinkCrab\Perique\Services\View\PHP_Engine;
 
 trait App_Helper_Trait {
 
@@ -54,6 +57,16 @@ trait App_Helper_Trait {
 			$app->registration_classes( $class );
 		}
 		$app->set_app_config( array() );
+
+		$container->addRules(
+			array(
+				'*' => array(
+					'substitutions' => array(
+						Renderable::class => new PHP_Engine( \FIXTURES . '/Views' ),
+					),
+				),
+			)
+		);
 
 		return $app;
 	}

--- a/tests/Application/Post_Type/Test_MetaBox_CPT.php
+++ b/tests/Application/Post_Type/Test_MetaBox_CPT.php
@@ -121,16 +121,20 @@ class Test_MetaBox_CPT extends WP_UnitTestCase {
 		$box = $this->meta_box_inspector->find( 'metabox_cpt_side' );
 		$this->assertNotNull( $box );
 
+		// Create the mock post and its matching meta.
+		$post = $this->factory->post->create( array( 'post_type' => $this->cpt->key ) );
+		\update_post_meta($post, 'pc_mock_meta', 'hello');
+
 		// Grab the view contents.
 		$view_output = Output::buffer(
-			function() use ( $box ) {
-				$this->meta_box_inspector->render_meta_box(
+			function() use ( $box, $post ) {
+				$this->meta_box_inspector->set_meta_boxes()->render_meta_box(
 					$box,
-					\get_post( $this->factory->post->create( array( 'post_type' => $this->cpt->key ) ) )
+					\get_post( $post )
 				);
 			}
 		);
-		$this->assertEquals( 'metabox_cpt_side VIEW', $view_output );
+		$this->assertEquals( 'metabox_cpt_side VIEW. Meta=hello', $view_output );
 
 		// Check title.
 		$this->assertEquals( 'metabox_cpt_side TITLE', $box->title );
@@ -138,5 +142,35 @@ class Test_MetaBox_CPT extends WP_UnitTestCase {
 		// Check view vars.
 		$this->assertArrayHasKey( 'key2', $box->args );
 		$this->assertEquals( 2, $box->args['key2'] );
+	}
+
+	public function test_template_metabox_registered()
+	{
+		// Check metabox exists.
+		$box = $this->meta_box_inspector->find( 'metabox_cpt_template' );
+		$this->assertNotNull( $box );
+
+		// Create the mock post and its matching meta.
+		$post = $this->factory->post->create( array( 'post_type' => $this->cpt->key ) );
+		\update_post_meta($post, 'pc_mock_meta', 'hello');
+
+		// Grab the view contents.
+		$view_output = Output::buffer(
+			function() use ( $box, $post ) {
+				$this->meta_box_inspector->set_meta_boxes()->render_meta_box(
+					$box,
+					\get_post( $post )
+				);
+			}
+		);
+
+		$this->assertEquals('Post Type: metabox_cpt, Meta: metabox_cpt_template', $view_output);
+
+		// Check title.
+		$this->assertEquals( 'metabox_cpt_template TITLE', $box->title );
+
+		// Check view vars.
+		$this->assertArrayHasKey( 'key3', $box->args );
+		$this->assertEquals( 3, $box->args['key3'] );
 	}
 }

--- a/tests/Fixtures/CPT/MetaBox_CPT.php
+++ b/tests/Fixtures/CPT/MetaBox_CPT.php
@@ -35,9 +35,29 @@ class MetaBox_CPT extends Post_Type {
 			->label( 'metabox_cpt_side TITLE' )
 			->view(
 				function( \WP_Post $post, array $args ) {
-					print( 'metabox_cpt_side VIEW' );
+					dump( $args );
+					print( 'metabox_cpt_side VIEW.' );
+					print( ' Meta=' . $args['args']['meta'] );
 				}
-			)->view_vars( array( 'key2' => 2 ) );
+			)
+			->view_vars( array( 'key2' => 2 ) )
+			->view_data_filter(
+				function( array $args ): array {
+					$args['meta'] = 'hello';
+					return $args;
+				}
+			);
+
+		$collection[] = Meta_Box::side( 'metabox_cpt_template' )
+			->label( 'metabox_cpt_template TITLE' )
+			->view_template('metabox.php')
+			->view_vars( array( 'key3' => 3 ) )
+			->view_data_filter(
+				function( array $args ): array {
+					$args['meta'] = 'metabox_cpt_template';
+					return $args;
+				}
+			);
 
 		return $collection;
 	}

--- a/tests/Fixtures/CPT/MetaBox_CPT.php
+++ b/tests/Fixtures/CPT/MetaBox_CPT.php
@@ -35,14 +35,13 @@ class MetaBox_CPT extends Post_Type {
 			->label( 'metabox_cpt_side TITLE' )
 			->view(
 				function( \WP_Post $post, array $args ) {
-					dump( $args );
 					print( 'metabox_cpt_side VIEW.' );
 					print( ' Meta=' . $args['args']['meta'] );
 				}
 			)
 			->view_vars( array( 'key2' => 2 ) )
 			->view_data_filter(
-				function( array $args ): array {
+				function( \WP_Post $post, array $args ): array {
 					$args['meta'] = 'hello';
 					return $args;
 				}
@@ -53,7 +52,7 @@ class MetaBox_CPT extends Post_Type {
 			->view_template('metabox.php')
 			->view_vars( array( 'key3' => 3 ) )
 			->view_data_filter(
-				function( array $args ): array {
+				function( \WP_Post $post, array $args ): array {
 					$args['meta'] = 'metabox_cpt_template';
 					return $args;
 				}

--- a/tests/Fixtures/Views/metabox.php
+++ b/tests/Fixtures/Views/metabox.php
@@ -1,0 +1,1 @@
+Post Type: <?php echo $post->post_type; ?>, Meta: <?php echo $meta; ?>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -27,3 +27,5 @@ tests_add_filter( 'muplugins_loaded', function() {} );
 // Start up the WP testing environment.
 require getenv( 'WP_PHPUNIT__DIR' ) . '/includes/bootstrap.php';
 
+define( 'FIXTURES', __DIR__ . '/Fixtures' );
+


### PR DESCRIPTION
Now has an optional filter which allows for the passing of variable populated at load to view.

calling 

```php
$meta_box->view_data_filter(
  function( WP_Post $post, array $args ): array {
    $args['meta'] = esc_html( get_post_meta($post->ID, 'some_key', true) );
    return $args;
  }
)
```
Then in your template
```php
<p><?php echo $meta; ?></p>
```